### PR TITLE
Update IdentityFile Defaults to Match Documentation

### DIFF
--- a/config.go
+++ b/config.go
@@ -50,6 +50,13 @@ var _ = version
 
 type configFinder func() string
 
+type config interface {
+	getinternal(alias, key string) string
+}
+
+var _ config = &UserSettings{}
+var _ config = &Config{}
+
 // UserSettings checks ~/.ssh and /etc/ssh for configuration files. The config
 // files are parsed and cached the first time Get() or GetStrict() is called.
 type UserSettings struct {
@@ -180,6 +187,10 @@ func (u *UserSettings) Get(alias, key string) string {
 	return val
 }
 
+func (u *UserSettings) getinternal(alias, key string) string {
+	return u.Get(alias, key)
+}
+
 // GetAll retrieves zero or more directives for key for the given alias. GetAll
 // returns nil if no value was found, or if IgnoreErrors is false and we could
 // not parse the configuration file. Use GetStrict to disambiguate the latter
@@ -237,11 +248,7 @@ func (u *UserSettings) GetAllStrict(alias, key string) ([]string, error) {
 	if err2 != nil || val2 != nil {
 		return val2, err2
 	}
-	// TODO: IdentityFile has multiple default values that we should return.
-	if def := Default(key); def != "" {
-		return []string{def}, nil
-	}
-	return []string{}, nil
+	return DefaultAll(key, alias, u), nil
 }
 
 func (u *UserSettings) doLoadConfigs() {
@@ -363,6 +370,11 @@ func (c *Config) Get(alias, key string) (string, error) {
 		}
 	}
 	return "", nil
+}
+
+func (c *Config) getinternal(alias, key string) string {
+	v, _ := c.Get(alias, key)
+	return v
 }
 
 // GetAll returns all values in the configuration that match the alias and

--- a/config_test.go
+++ b/config_test.go
@@ -107,8 +107,7 @@ func TestGetIdentities(t *testing.T) {
 		t.Errorf("expected nil err, got %v", err)
 	}
 	if len(val) != len(defaultProtocol2Identities) {
-		// TODO: return the right values here.
-		log.Printf("expected defaults, got %v", val)
+		t.Errorf("expected defaults, got %v", val)
 	} else {
 		for i, v := range defaultProtocol2Identities {
 			if val[i] != v {

--- a/validators.go
+++ b/validators.go
@@ -183,10 +183,12 @@ var defaults = map[string]string{
 
 // these identities are used for SSH protocol 2
 var defaultProtocol2Identities = []string{
-	"~/.ssh/id_dsa",
-	"~/.ssh/id_ecdsa",
-	"~/.ssh/id_ed25519",
 	"~/.ssh/id_rsa",
+	"~/.ssh/id_ecdsa",
+	"~/.ssh/id_ecdsa_sk",
+	"~/.ssh/id_ed25519",
+	"~/.ssh/id_ed25519_sk",
+	"~/.ssh/id_dsa",
 }
 
 // these directives support multiple items that can be collected

--- a/validators.go
+++ b/validators.go
@@ -15,6 +15,26 @@ func Default(keyword string) string {
 	return defaults[strings.ToLower(keyword)]
 }
 
+// DefaultAll returns the default value for the given keyword, but as a slice. If
+// there is no default for the keyword, nil is returned.
+//
+// Some multi-valued settings have different defaults based on other settings, so
+// you must provide the host alias and a config to retrieve a setting from
+func DefaultAll(keyword string, alias string, cfg config) []string {
+	if strings.ToLower(keyword) == "identityfile" && cfg.getinternal(alias, "Protocol") == "2" {
+		def := make([]string, len(defaultProtocol2Identities))
+		copy(def, defaultProtocol2Identities)
+		return def
+	}
+
+	def := Default(keyword)
+	if def != "" {
+		return []string{def}
+	}
+
+	return nil
+}
+
 // Arguments where the value must be "yes" or "no" and *only* yes or no.
 var yesnos = map[string]bool{
 	strings.ToLower("BatchMode"):                        true,


### PR DESCRIPTION
In the previous versions, IdentityFile defaulted to ~/.ssh/identity which was the convention in ssh1 but not in the more modern ssh2 that is widely used these days. This updates the default values to the ssh2 defaults.