### PR TITLE
fix: persist ignoreMatchDirective to included file

### DIFF
--- a/config.go
+++ b/config.go
@@ -861,8 +861,9 @@ func init() {
 	}
 }
 
-func newConfig() *Config {
+func newConfig(ignoreMatchDirective bool) *Config {
 	return &Config{
+		ignoreMatchDirective: ignoreMatchDirective,
 		Hosts: []*Host{
 			&Host{
 				implicit: true,

--- a/parser.go
+++ b/parser.go
@@ -187,7 +187,7 @@ func parseSSH(flow chan token, system, ignoreMatchDirective bool, depth uint8) *
 		}
 	}()
 
-	result := newConfig()
+	result := newConfig(ignoreMatchDirective)
 	result.position = Position{1, 1}
 	parser := &sshParser{
 		ignoreMatchDirective: ignoreMatchDirective,


### PR DESCRIPTION
The ignoreMatchDirective flag did not exist in the newConfig function. Because this function is called when generating a config for connections in an included file, those connections automatically assumed the value was false. This change adds the flag so it can be changed to true if it is also set for the outer configuration.